### PR TITLE
Fix typo in link to website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This repository hosts the main website of the Cultural Heritage Data Science Network, which can be found at <https://cdhs.netlify.app/>.
+This repository hosts the main website of the Cultural Heritage Data Science Network, which can be found at <https://chds.netlify.app/>.
 
 # Community vision
 


### PR DESCRIPTION
----

`cdhs.netlify.app` → `chds.netlify.app`